### PR TITLE
Improve run_script_on_host to reduce errors

### DIFF
--- a/deployment_helper/templates/run_script_on_host.sh
+++ b/deployment_helper/templates/run_script_on_host.sh
@@ -29,7 +29,14 @@ function is_local()
 	return
     fi
     host=$(curl -s $AWS_PUBLIC_HOSTNAME_URL)
-    if [ $cmd_host == $host ]; then
+    # Catch curl failure
+    rc=$?
+    if [ $rc != 0 ]; then
+	echo 1
+	return
+    fi
+    # Catch potential empty response
+    if [ $cmd_host == "$host" ]; then
 	echo 1
 	return
     fi


### PR DESCRIPTION
* catch curl failure (e.g. Amaazon AWS URL not available)
* catch empty response from Amazon AWS curl request