### PR TITLE
Brief fix to prevent CELL from including a dash (could be improved)

### DIFF
--- a/deployment_helper/deployment_helper.py
+++ b/deployment_helper/deployment_helper.py
@@ -117,6 +117,9 @@ def read_value(prompt, default=''):
 def set_cell_and_keyspace(default_cell):
     global CELL, KEYSPACE
     CELL = os.environ.get('CELL') or read_value('Enter CELL name:', default_cell)
+    if '-' in CELL:
+        print("Error: CELL must not contain a '-' character")
+        sys.exit(1)
     default_keyspace = '%s_keyspace' % CELL
     KEYSPACE = read_value('Enter KEYSPACE name:', default_keyspace)
 


### PR DESCRIPTION
I hadn't realised that CELL may not contain hyphens and so generated a config which is not acceptable to Vitess. This change is a bit rough but prevents me continuing to add information when it will never be accepted.

Repeated validation of the input might be better but not sure the best way to handle that as current code does not seem to have any input validation handling etc.

This fix should do for now.