### PR TITLE
OSX does not support hostname -i so guard against this usage

### DIFF
--- a/deployment_helper/templates/run_script_on_host.sh
+++ b/deployment_helper/templates/run_script_on_host.sh
@@ -23,8 +23,8 @@ function is_local()
 	echo 1
 	return
     fi
-    host=$(hostname -i)
-    if [ "$cmd_host" == "$host" ]; then
+    # OSX does not support hostname -i
+    if [ "$(uname)" != Darwin -a "$cmd_host" == "$(hostname -i)" ]; then
 	echo 1
 	return
     fi


### PR DESCRIPTION
So add check for OSX to prevent running commands that won't work.